### PR TITLE
Hide right-side tab shadow

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -83,7 +83,7 @@ function generateCssFile(context) {
   }
 
   // fix for right side drop shadow
-  style += ".monaco-icon-label-container::after{display: none !important;}";
+  style += ".monaco-icon-label-container::after{background: #ff000000 !important;}";
 
   // fix for active tab opacity
   style += ".tab.active{opacity:1 !important}";

--- a/extension.js
+++ b/extension.js
@@ -83,7 +83,7 @@ function generateCssFile(context) {
   }
 
   // fix for right side drop shadow
-  style += ".monaco-icon-label-container::after{background: #ff000000 !important;}";
+  style += ".tab .monaco-icon-label-container:after, .tab .monaco-icon-name-container:after{background:transparent !important;}";
 
   // fix for active tab opacity
   style += ".tab.active{opacity:1 !important}";

--- a/extension.js
+++ b/extension.js
@@ -81,7 +81,13 @@ function generateCssFile(context) {
     style += `${tabSelector}{background-color:${byDirectory[a].backgroundColor} !important; opacity: ${byDirectory[a].opacity || "0.6"};}
     ${tabSelector} a,${tabSelector} .monaco-icon-label:after,${tabSelector} .monaco-icon-label:before{color:${byDirectory[a].fontColor} !important;}`;
   }
+
+  // fix for right side drop shadow
+  style += ".monaco-icon-label-container::after{display: none !important;}";
+
+  // fix for active tab opacity
   style += ".tab.active{opacity:1 !important}";
+
   if (activeTab.backgroundColor != "default") {
     style += `body .tabs-container .tab.active{background-color:${activeTab.backgroundColor} !important; }body .tabs-container .tab.active a,body .tabs-container .tab.active .monaco-icon-label:after,body .tabs-container .tab.active .monaco-icon-label:before{color:${activeTab.fontColor} !important;}`;
   }


### PR DESCRIPTION
Fix mentioned in https://github.com/mondersky/tabscolor-vscode/issues/39
- I think removing it is simpler
- but maybe some people may want to keep it even when colored wrong?