### PR TITLE
Hover color, shadows color, opacities...

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ example:
 "tabsColor.byFileType": {
     "js": {
       "backgroundColor": "yellow",
-      "fontColor": "black"
+      "fontColor": "black",
+      "opacity" : 0.6
     }
   }
 ```
@@ -42,7 +43,8 @@ example:
 "tabsColor.byDirectory": {
   "C:\\wamp\\www\\my_project\\css": {
     "backgroundColor": "#00efff",
-    "fontColor": "#ffffff"
+    "fontColor": "#ffffff",
+    "opacity" : 0.6
   }
 }
 ```
@@ -52,7 +54,8 @@ example 2 (partial path):
 "tabsColor.byDirectory": {
   "\\my_project\\": {
     "backgroundColor": "#00efff",
-    "fontColor": "#ffffff"
+    "fontColor": "#ffffff",
+    "opacity" : 0.6
   }
 }
 ```
@@ -64,7 +67,8 @@ example:
 ```
 "tabsColor.activeTab": {
   "backgroundColor": "yellow",
-  "fontColor": "black"
+  "fontColor": "black",
+  "opacity" : 1.0
 }
 ```
 Add this to your VS Code user `settings.json`

--- a/extension.js
+++ b/extension.js
@@ -74,9 +74,20 @@ function generateCssFile(context) {
   // set by type
   for (const a in byFileType) {
     if (a === "myfiletype") continue; // skip default
-    let tabSelector = `.tab[title*=".${formatTitle(a)}" i]`;
-    style += `${tabSelector}{background-color:${byFileType[a].backgroundColor} !important; opacity:${byFileType[a].opacity || default_opacity};}
-    ${tabSelector} a,${tabSelector} .monaco-icon-label:after,${tabSelector} .monaco-icon-label:before{color:${byFileType[a].fontColor} !important;}`;
+    let selector = `[title*=".${formatTitle(a)}" i]`;
+    let tabSelector = `.tab${selector}`;
+    // background, text, hover drop shadow ("workbench.editor.tabSizing")
+    style += `${tabSelector} {background-color:${byFileType[a].backgroundColor} !important; opacity:${byFileType[a].opacity || default_opacity};}`;
+    style += `${tabSelector} a,${tabSelector} .monaco-icon-label:after,${tabSelector} .monaco-icon-label:before {color:${byFileType[a].fontColor} !important;}`;
+    style += `${tabSelector} .monaco-icon-label-container::after {background: linear-gradient(to left, ${byFileType[a].backgroundColor}, transparent) !important;}`;
+
+    // hover background
+    style += `.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > ${tabSelector}:hover {background-color:${byFileType[a].backgroundColor} !important;}`;
+
+    // hover drop shadow ("workbench.editor.tabSizing"): we need specificity >= 17 -> 14 + :hover 3 times, also for both settings "shrink" and "fixed"
+    style += `.monaco-workbench .part.editor > .content .editor-group-container.active:hover > .title .tabs-container:hover > .tab.sizing-shrink${selector}:hover > .tab-label > .monaco-icon-label-container::after,
+              .monaco-workbench .part.editor > .content .editor-group-container.active:hover > .title .tabs-container:hover > .tab.sizing-fixed${selector}:hover > .tab-label > .monaco-icon-label-container::after
+              {background: linear-gradient(to left, ${byFileType[a].backgroundColor}, transparent) !important;}`
   }
 
   // set by folder

--- a/extension.js
+++ b/extension.js
@@ -76,15 +76,13 @@ function generateCssFile(context) {
     if (a === "myfiletype") continue; // skip default
     let selector = `[title*=".${formatTitle(a)}" i]`;
     let tabSelector = `.tab${selector}`;
-    // background, text, hover drop shadow ("workbench.editor.tabSizing")
+    // background, text, right side shadow ("workbench.editor.tabSizing")
     style += `${tabSelector} {background-color:${byFileType[a].backgroundColor} !important; opacity:${byFileType[a].opacity || default_opacity};}`;
     style += `${tabSelector} a,${tabSelector} .monaco-icon-label:after,${tabSelector} .monaco-icon-label:before {color:${byFileType[a].fontColor} !important;}`;
     style += `${tabSelector} .monaco-icon-label-container::after {background: linear-gradient(to left, ${byFileType[a].backgroundColor}, transparent) !important;}`;
-
     // hover background
     style += `.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > ${tabSelector}:hover {background-color:${byFileType[a].backgroundColor} !important;}`;
-
-    // hover drop shadow ("workbench.editor.tabSizing"): we need specificity >= 17 -> 14 + :hover 3 times, also for both settings "shrink" and "fixed"
+    // hover right side shadow: we need specificity >= 17 -> 14 + :hover 3 times, also for both settings "shrink" and "fixed"
     style += `.monaco-workbench .part.editor > .content .editor-group-container.active:hover > .title .tabs-container:hover > .tab.sizing-shrink${selector}:hover > .tab-label > .monaco-icon-label-container::after,
               .monaco-workbench .part.editor > .content .editor-group-container.active:hover > .title .tabs-container:hover > .tab.sizing-fixed${selector}:hover > .tab-label > .monaco-icon-label-container::after
               {background: linear-gradient(to left, ${byFileType[a].backgroundColor}, transparent) !important;}`
@@ -94,13 +92,19 @@ function generateCssFile(context) {
   for (const a in byDirectory) {
     if (a === "C:\\my\\directory\\") continue; // skip default
     const title = a.replace(/\\/g, "\\\\");
-    let tabSelector = `.tab[title*="${formatTitle(title)}" i]`;
-    style += `${tabSelector}{background-color:${byDirectory[a].backgroundColor} !important; opacity: ${byDirectory[a].opacity || default_opacity};}
-    ${tabSelector} a,${tabSelector} .monaco-icon-label:after,${tabSelector} .monaco-icon-label:before{color:${byDirectory[a].fontColor} !important;}`;
+    let selector = `[title*="${formatTitle(title)}" i]`;
+    let tabSelector = `.tab${selector}`;
+    // background, text, right side shadow ("workbench.editor.tabSizing")
+    style += `${tabSelector}{background-color:${byDirectory[a].backgroundColor} !important; opacity: ${byDirectory[a].opacity || default_opacity};}`;
+    style += `${tabSelector} a,${tabSelector} .monaco-icon-label:after,${tabSelector} .monaco-icon-label:before{color:${byDirectory[a].fontColor} !important;}`;
+    style += `${tabSelector} .monaco-icon-label-container::after {background: linear-gradient(to left, ${byDirectory[a].backgroundColor}, transparent) !important;}`;
+    // hover background
+    style += `.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > ${tabSelector}:hover {background-color:${byDirectory[a].backgroundColor} !important;}`;
+    // hover right side shadow: we need specificity >= 17 -> 14 + :hover 3 times, also for both settings "shrink" and "fixed"
+    style += `.monaco-workbench .part.editor > .content .editor-group-container.active:hover > .title .tabs-container:hover > .tab.sizing-shrink${selector}:hover > .tab-label > .monaco-icon-label-container::after,
+              .monaco-workbench .part.editor > .content .editor-group-container.active:hover > .title .tabs-container:hover > .tab.sizing-fixed${selector}:hover > .tab-label > .monaco-icon-label-container::after
+              {background: linear-gradient(to left, ${byDirectory[a].backgroundColor}, transparent) !important;}`
   }
-  
-  // fix for right side drop shadow
-  style += ".tab .monaco-icon-label-container:after, .tab .monaco-icon-name-container:after{background:transparent !important;}";
 
   // override for active tab opacity
   style += `.tab.active{opacity:${activeTab.opacity || "1"} !important}`;

--- a/extension.js
+++ b/extension.js
@@ -65,13 +65,14 @@ function generateCssFile(context) {
   const cssFile = path.join(modulesPath(context), "inject.css");
   const data = "";
   const tabs = storage.get("tabs") || {};
+  const default_opacity = "0.6";
   let style = "";
   const homeDir = os.homedir() + '/';
 
   for (const a in byFileType) {
     if (a == "filetype") continue;
     let tabSelector = `.tab[title*=".${formatTitle(a)}" i]`;
-    style += `${tabSelector}{background-color:${byFileType[a].backgroundColor} !important; opacity:${byFileType[a].opacity || "0.6"};}
+    style += `${tabSelector}{background-color:${byFileType[a].backgroundColor} !important; opacity:${byFileType[a].opacity || default_opacity};}
     ${tabSelector} a,${tabSelector} .monaco-icon-label:after,${tabSelector} .monaco-icon-label:before{color:${byFileType[a].fontColor} !important;}`;
   }
   
@@ -79,19 +80,24 @@ function generateCssFile(context) {
     if (a === "my/directory/" || a === "C:\\my\\directory\\") continue;
     const title = a.replace(/\\/g, "\\\\");
     let tabSelector = `.tab[title*="${formatTitle(title)}" i]`;
-    style += `${tabSelector}{background-color:${byDirectory[a].backgroundColor} !important; opacity: ${byDirectory[a].opacity || "0.6"};}
+    style += `${tabSelector}{background-color:${byDirectory[a].backgroundColor} !important; opacity: ${byDirectory[a].opacity || default_opacity};}
     ${tabSelector} a,${tabSelector} .monaco-icon-label:after,${tabSelector} .monaco-icon-label:before{color:${byDirectory[a].fontColor} !important;}`;
   }
   
   // fix for right side drop shadow
   style += ".tab .monaco-icon-label-container:after, .tab .monaco-icon-name-container:after{background:transparent !important;}";
 
-  // fix for active tab opacity
-  style += ".tab.active{opacity:1 !important}";
+  // override for active tab opacity
+  style += `.tab.active{opacity:${activeTab.opacity || "1"} !important}`;
 
+  // set active (override user settings + custom colors)
   if (activeTab.backgroundColor != "default") {
-    style += `body .tabs-container .tab.active{background-color:${activeTab.backgroundColor} !important; }body .tabs-container .tab.active a,body .tabs-container .tab.active .monaco-icon-label:after,body .tabs-container .tab.active .monaco-icon-label:before{color:${activeTab.fontColor} !important;}`;
+    style += `body .tabs-container .tab.active{background-color:${activeTab.backgroundColor} !important; }`;
   }
+  if (activeTab.fontColor != "default") {
+    style += `body .tabs-container .tab.active a,body .tabs-container .tab.active .monaco-icon-label:after,body .tabs-container .tab.active .monaco-icon-label:before{color:${activeTab.fontColor} !important;}`;
+  }
+
   let activeSelectors = "";
   const activeSelectorsArr = [];
   const colorsData = { ...storage.get("customColors"), ...storage.get("defaultColors") };
@@ -102,7 +108,7 @@ function generateCssFile(context) {
     let fontColorSelectors = "";
     const _background = colorsData[i].background;
     const _fontColor = colorsData[i].color;
-    const _opacity = colorsData[i].opacity || "0.6";
+    const _opacity = colorsData[i].opacity || default_opacity;
     const backgroundSelectorsArr = _colorTabs.map(function (a) {
       return `.tab[title*="${formatTitle(a)}" i]`;
     });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 					"default": {
 						"myfiletype": {
 							"backgroundColor": "red",
-							"fontColor": "white"
+							"fontColor": "white",
+							"opacity": "0.6",
 						}
 					},
 					"description": "Automatically color tabs based on their file type. See example on the extension page "
@@ -48,7 +49,8 @@
 					"default": {
 						"C:\\my\\directory\\": {
 							"backgroundColor": "#ffffff",
-							"fontColor": "#000000"
+							"fontColor": "#000000",
+							"opacity": "0.6",
 						}
 					},
 					"description": "Automatically color tabs based on their parent folder path. See example on the extension page"
@@ -57,7 +59,8 @@
 					"type": "object",
 					"default": {
 						"backgroundColor": "default",
-						"fontColor": "default"
+						"fontColor": "default",
+						"opacity": "1.0",
 					},
 					"description": "Color of the active tab"
 				}


### PR DESCRIPTION
Following https://github.com/mondersky/tabscolor-vscode/pull/43

I spread out the commits but the summary'd be:

- sets the color for hovered tabs: long selector to override !important
- sets the color for hovered right side shadows
- sets the color for right side shadows (instead of removing them): even longer selector oof
- I also added a couple of tweaks along the way:
  - allow custom active tab color with default background
  - updated skipping writing styles for the default configs
  - default opacity in the manifest/readme?
  - comment each part of the styling code

Please try it out first as I dont have the means of building right now and what I usually do is to edit the instance inject.css in the inspector direclty, thanks.

Again feel free to edit or comment anything!
