### PR TITLE
Feature/colortabs for folder & child items inherit from parent folder

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1449,6 +1449,12 @@ function folderKeyFromUri(uri) {
   return ensureTrailingSep(uriPathForKey(uri));
 }
 
+function folderKeyAbsoluteFromUri(uri) {
+  if (!uri) return "";
+  const p = uriPathForKey(uri);
+  return ensureTrailingSep(p || "");
+}
+
 function normDirKey(s) {
   return (s || "")
     .replace(/\\/g, "/")
@@ -1541,7 +1547,8 @@ async function setFolderColorRule(context, folderUri, colorName) {
     return vscode.window.showErrorMessage(`Unknown color "${colorName}"`);
   }
 
-  const key = folderKeyFromUri(folderUri);
+  // Store absolute key for platform-correct matching.
+  const key = folderKeyAbsoluteFromUri(folderUri);
   if (!key) return;
 
   const cfg = vscode.workspace.getConfiguration("tabsColor");

--- a/package.json
+++ b/package.json
@@ -150,18 +150,13 @@
 				"category": "TabsColor functions"
 			},
 			{
-				"command": "tabscolor.randomColor",
-				"title": "random color",
-				"category": "TabsColor colors"
-			},
-			{
 				"command": "tabscolor.addColor",
-				"title": "add color",
+				"title": "add custom color",
 				"category": "TabsColor functions"
 			},
 			{
 				"command": "tabscolor.more",
-				"title": "more",
+				"title": "Select custom color",
 				"category": "TabsColor colors"
 			},
 			{
@@ -173,6 +168,51 @@
 				"command": "tabscolor.clearOpenTabColors",
 				"title": "Clear All Open Tab Colors",
 				"category": "TabsColor functions"
+			},
+			{
+				"command": "tabscolor.folderColor.blue",
+				"title": "blue",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderColor.salmon",
+				"title": "salmon",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderColor.green",
+				"title": "green",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderColor.red",
+				"title": "red",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderColor.orange",
+				"title": "orange",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderColor.yellow",
+				"title": "yellow",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderColor.black",
+				"title": "black",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderColor.white",
+				"title": "white",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.clearFolderColor",
+				"title": "Clear folder tab color",
+				"category": "TabsColor folders"
 			}
 		],
 		"menus": {
@@ -181,6 +221,60 @@
 					"submenu": "colors",
 					"group": "navigation",
 					"title": "color"
+				}
+			],
+			"explorer/context": [
+				{
+					"submenu": "folderColors",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				}
+			],
+			"folderColors": [
+				{
+					"command": "tabscolor.folderColor.blue",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderColor.salmon",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderColor.green",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderColor.red",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderColor.orange",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderColor.yellow",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderColor.black",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderColor.white",
+					"group": "navigation",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.clearFolderColor",
+					"group": "functions",
+					"when": "explorerResourceIsFolder"
 				}
 			],
 			"colors": [
@@ -242,6 +336,10 @@
 			{
 				"id": "colors",
 				"label": "Color"
+			},
+			{
+				"id": "folderColors",
+				"label": "Folder Color"
 			}
 		]
 	},
@@ -270,6 +368,9 @@
 		"id": "da199d98-50b1-4ae5-bcf7-27a9bf1b9e0a",
 		"publisherDisplayName": "mondersky",
 		"publisherId": "1355920c-d02e-47e8-8d1a-d2f59c078d43",
-		"isPreReleaseVersion": false
+		"isPreReleaseVersion": false,
+		"installedTimestamp": 1770111471451,
+		"targetPlatform": "undefined",
+		"size": 128866
 	}
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,15 @@
 					},
 					"description": "Automatically color tabs based on their parent folder path. See example on the extension page"
 				},
+				"tabsColor.folderMatchStrategy": {
+					"type": "string",
+					"enum": [
+						"nearest",
+						"asDefined"
+					],
+					"default": "nearest",
+					"description": "When multiple folder rules match a tab, choose whether the nearest (most specific) folder wins or use rule order as defined."
+				},
 				"tabsColor.activeTab": {
 					"type": "object",
 					"default": {
@@ -66,7 +75,7 @@
 		"commands": [
 			{
 				"command": "tabscolor.none",
-				"title": "none",
+				"title": "Clear tab color",
 				"category": "TabsColor colors"
 			},
 			{
@@ -150,6 +159,21 @@
 				"category": "TabsColor functions"
 			},
 			{
+				"command": "tabscolor.clearFolderColors",
+				"title": "clear all folder colors",
+				"category": "TabsColor functions"
+			},
+			{
+				"command": "tabscolor.clearAllColors",
+				"title": "clear all colors",
+				"category": "TabsColor functions"
+			},
+			{
+				"command": "tabscolor.clearFolderColorsByColor",
+				"title": "remove folder colors by color",
+				"category": "TabsColor functions"
+			},
+			{
 				"command": "tabscolor.addColor",
 				"title": "add custom color",
 				"category": "TabsColor functions"
@@ -213,6 +237,21 @@
 				"command": "tabscolor.clearFolderColor",
 				"title": "Clear folder tab color",
 				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderAddColor",
+				"title": "add custom color",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderSelectCustomColor",
+				"title": "Select custom color",
+				"category": "TabsColor folders"
+			},
+			{
+				"command": "tabscolor.folderDeleteCustomColor",
+				"title": "delete custom color",
+				"category": "TabsColor folders"
 			}
 		],
 		"menus": {
@@ -273,6 +312,21 @@
 				},
 				{
 					"command": "tabscolor.clearFolderColor",
+					"group": "functions",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderAddColor",
+					"group": "functions",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderSelectCustomColor",
+					"group": "functions",
+					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "tabscolor.folderDeleteCustomColor",
 					"group": "functions",
 					"when": "explorerResourceIsFolder"
 				}

--- a/package.json
+++ b/package.json
@@ -264,6 +264,12 @@
 			],
 			"explorer/context": [
 				{
+					"submenu": "colors",
+					"group": "navigation",
+					"title": "color",
+					"when": "!explorerResourceIsFolder"
+				},
+				{
 					"submenu": "folderColors",
 					"group": "navigation",
 					"when": "explorerResourceIsFolder"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"commands": [
 			{
 				"command": "tabscolor.none",
-				"title": "Clear tab color",
+				"title": "clear tab color",
 				"category": "TabsColor colors"
 			},
 			{
@@ -235,7 +235,7 @@
 			},
 			{
 				"command": "tabscolor.clearFolderColor",
-				"title": "Clear folder tab color",
+				"title": "clear folder tab color",
 				"category": "TabsColor folders"
 			},
 			{


### PR DESCRIPTION
This PR expands folder coloring so you can set a color once on a folder and have all child tabs inherit it.
no more manual per‑tab coloring for each component. It also adds missing folder menu actions to match the tab
workflow and improves how overlapping folder rules resolve.

Key changes:

- Added folder context menu actions to match tab actions:
- Add custom color
- Select custom color
- Delete custom color
- Added Command Palette commands:
- Clear all folder colors
- Clear all colors (tabs + folders)
- Remove folder colors by color (bulk delete)
- Introduced tabsColor.folderMatchStrategy (default nearest) so the most specific folder rule wins when multiple rules match.
- Feature/Add folder custom color tools, nearest‑match behavior, and bulk clear command

- Renamed the “none” tab command to “Clear tab color” for clarity.
- Deleting a custom color now removes any folder rules using that color.

Why:
The goal is fast, scalable coloring by component folder. This makes folder coloring first‑class and removes
the need to set colors per file/tab.

Files changed:

- extension.js
- package.json